### PR TITLE
Add transports-dialyse project button

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,8 +66,9 @@
   <main>
     <ul class="project-list">
       <li><a href="/Flisp2/">Projet FLISP</a><br><small>Suivi du flux de liaison interdisciplinaire social avec le patient</small></li>
-      <li><a href="https://ludox808.github.io/eladeb3/" target="_blank">Projet Eladeb</a><br><small>Outil d’évaluation psychosociale numérique en cours de développement</small></li>
-      <li><a href="/about/">À propos d’Hospisoc</a><br><small>Mission, objectifs et partenaires</small></li>
+        <li><a href="https://ludox808.github.io/eladeb3/" target="_blank">Projet Eladeb</a><br><small>Outil d’évaluation psychosociale numérique en cours de développement</small></li>
+        <li><a href="/transports-dialyse/">Projet transports-dialyse</a><br><small>Organisation du transport pour patients en dialyse</small></li>
+        <li><a href="/about/">À propos d’Hospisoc</a><br><small>Mission, objectifs et partenaires</small></li>
     </ul>
   </main>
   <footer>

--- a/transports-dialyse/index.html
+++ b/transports-dialyse/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Projet transports-dialyse</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2rem; background-color: #f9f9f9; color: #333; }
+    h1 { color: #005a9c; }
+    p { max-width: 700px; line-height: 1.6; }
+    a { color: #005a9c; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>Projet transports-dialyse</h1>
+  <p>Ce projet vise à optimiser l'organisation des transports pour les patients en dialyse.</p>
+  <p>La plateforme est actuellement en développement.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new "Projet transports-dialyse" link in project list
- provide placeholder page for transports-dialyse

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859095914148333951b79c0be3a7dab