### PR TITLE
Add eladeb3 directory and update links

### DIFF
--- a/eladeb3/index.html
+++ b/eladeb3/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>Projet FLISP</title>
+  <title>Projet Eladeb</title>
   <style>
     body { font-family: Arial, sans-serif; padding: 2rem; background-color: #f9f9f9; color: #333; }
     h1 { color: #005a9c; }
@@ -12,9 +12,8 @@
   </style>
 </head>
 <body>
-  <h1>Projet FLISP</h1>
-  <p>Le projet FLISP vise à améliorer le partage d’informations sociales et médicales entre les acteurs de première et de deuxième ligne.</p>
-  <p>Ce projet est porté par Hospisoc en collaboration avec plusieurs partenaires hospitaliers et extrahospitaliers.</p>
-  <p><a href="/Flisp2/">Voir la version complète</a></p>
+  <h1>Projet Eladeb</h1>
+  <p>Eladeb est un outil d’évaluation psychosociale numérique actuellement en développement.</p>
+  <p>Plus d’informations seront disponibles prochainement.</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
   <main>
     <ul class="project-list">
       <li><a href="/Flisp2/">Projet FLISP</a><br><small>Suivi du flux de liaison interdisciplinaire social avec le patient</small></li>
-        <li><a href="https://ludox808.github.io/eladeb3/" target="_blank">Projet Eladeb</a><br><small>Outil d’évaluation psychosociale numérique en cours de développement</small></li>
+        <li><a href="/eladeb3/">Projet Eladeb</a><br><small>Outil d’évaluation psychosociale numérique en cours de développement</small></li>
         <li><a href="/transports-dialyse/">Projet transports-dialyse</a><br><small>Organisation du transport pour patients en dialyse</small></li>
         <li><a href="/about/">À propos d’Hospisoc</a><br><small>Mission, objectifs et partenaires</small></li>
     </ul>


### PR DESCRIPTION
## Summary
- include a simple placeholder page for Eladeb
- link the home page to `/eladeb3/`
- point the FLISP page's link to a relative URL

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685a8f13fb108333a8a933ae9d9144c9