### PR TITLE
Implement automatic redirect for FLISP

### DIFF
--- a/Flisp2/index.html
+++ b/Flisp2/index.html
@@ -2,19 +2,13 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
-  <title>Projet FLISP</title>
-  <style>
-    body { font-family: Arial, sans-serif; padding: 2rem; background-color: #f9f9f9; color: #333; }
-    h1 { color: #005a9c; }
-    p { max-width: 700px; line-height: 1.6; }
-    a { color: #005a9c; text-decoration: none; }
-    a:hover { text-decoration: underline; }
-  </style>
+  <title>Redirection...</title>
+  <meta http-equiv="refresh" content="0; url=index.html" />
+  <script>
+    // Fallback pour les navigateurs ne gérant pas la meta refresh
+    window.location.replace('index.html');
+  </script>
 </head>
 <body>
-  <h1>Projet FLISP</h1>
-  <p>Le projet FLISP vise à améliorer le partage d’informations sociales et médicales entre les acteurs de première et de deuxième ligne.</p>
-  <p>Ce projet est porté par Hospisoc en collaboration avec plusieurs partenaires hospitaliers et extrahospitaliers.</p>
-  <p><a href="/Flisp2/">Voir la version complète</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the FLISP introduction page with an immediate redirect

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a94e4cf2083338de01bdaf15a7339