### PR TITLE
Add about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository hosts the static website available at [projets.hospisoc.be](http
 - **FLISP** (`/Flisp2/`): prototype for better social and medical information flow between care professionals.
 - **Transports Dialyse** (`/transports-dialyse/`): site exploring transport organisation for dialysis patients.
 - **Eladeb**: external psychosocial evaluation tool linked from the main page.
-- An "About Hospisoc" section is planned under `/about/`.
+- An "About Hospisoc" section is available under `/about/`.
 
 ## Building and deploying
 

--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>À propos d'Hospisoc</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 2rem;
+      background-color: #f7fafd;
+      color: #333;
+    }
+    h1 {
+      color: #2e3c54;
+    }
+    p {
+      max-width: 800px;
+      line-height: 1.6;
+    }
+    a {
+      color: #2e3c54;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <h1>Hospisoc&nbsp;: mission et vision</h1>
+  <p>Hospisoc est un collectif d'assistants sociaux hospitaliers qui promeut la
+  coopération entre les secteurs de la santé et du social.</p>
+  <p>Notre mission est de développer des outils et des projets numériques
+  facilitant le partage d'informations, l'accompagnement des patients et la
+  recherche sociale en milieu hospitalier.</p>
+  <p>Les initiatives présentées sur ce site sont expérimentales et reposent sur
+  la collaboration de nombreux partenaires.</p>
+  <p><a href="../index.html">&larr; Retour à l'accueil</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `/about/` section explaining Hospisoc's mission
- mention about section in README

## Testing
- `pytest -q`
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685a962775088333b914fb7c11fe2b66