### PR TITLE
Fix FLISP redirect

### DIFF
--- a/Flisp2/index.html
+++ b/Flisp2/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8">
   <title>Redirection...</title>
-  <meta http-equiv="refresh" content="0; url=index.html" />
+  <meta http-equiv="refresh" content="0; url=/Flisp2/app/" />
   <script>
     // Fallback pour les navigateurs ne gérant pas la meta refresh
-    window.location.replace('index.html');
+    window.location.replace('/Flisp2/app/');
   </script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- update `/Flisp2/` redirect to point at `/Flisp2/app/`

## Testing
- `python3 -m http.server 8000`
- `curl -s http://localhost:8000/Flisp2/ | head -n 10`

------
https://chatgpt.com/codex/tasks/task_e_685a962a4ac48333946b3af4d763926e