### PR TITLE
Fix image paths and alt text in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,14 +125,14 @@
 </head>
 <body>
   <header>
-    <img src="/illustrations-vignettes/logo-hospisoc.png" alt="Logo Hospisoc">
+    <img src="./illustrations-vignettes/logo-hospisoc.png" alt="Logo Hospisoc">
     <h1>Portail des projets Hospisoc</h1>
     <p>Accès rapide à nos projets en cours</p>
   </header>
 
   <main class="projects">
     <div class="card">
-      <img src="/illustrations-vignettes/flisp.png" alt="FLISP">
+      <img src="./illustrations-vignettes/flisp.png" alt="Logo FLISP">
       <div class="card-body">
         <div class="icon"><i class="fas fa-network-wired"></i></div>
         <h3>FLISP</h3>
@@ -142,7 +142,7 @@
     </div>
 
     <div class="card">
-      <img src="/illustrations-vignettes/Eladeb.png" alt="ELADEB">
+      <img src="./illustrations-vignettes/eladeb.png" alt="Logo ELADEB">
       <div class="card-body">
         <div class="icon"><i class="fas fa-user-check"></i></div>
         <h3>ELADEB</h3>
@@ -152,7 +152,7 @@
     </div>
 
     <div class="card">
-      <img src="/illustrations-vignettes/Transports.png" alt="Transports-dialyse">
+      <img src="./illustrations-vignettes/transports-dialyse.png" alt="Logo Transports-dialyse">
       <div class="card-body">
         <div class="icon"><i class="fas fa-ambulance"></i></div>
         <h3>Transports-dialyse</h3>


### PR DESCRIPTION
## Summary
- update `<img>` tags in `index.html` to use relative paths
- add more descriptive `alt` attributes

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685ad3f750fc8333b694cbc1d33b146a