### PR TITLE
Fix image paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
 </head>
 <body>
   <header>
-    <img src="./illustrations-vignettes/logo-hospisoc.png" alt="Logo Hospisoc" style="height: 50px;">
+    <img src="./illustrations-vignettes/Logo hospisoc.png" alt="Logo Hospisoc" style="height: 50px;">
     <h1>Portail des projets Hospisoc</h1>
     <p>Accès rapide à nos projets en cours</p>
   </header>
@@ -142,7 +142,7 @@
     </div>
 
     <div class="card">
-      <img src="./illustrations-vignettes/eladeb.png" alt="Logo ELADEB">
+      <img src="./illustrations-vignettes/Eladeb.png" alt="Logo ELADEB">
       <div class="card-body">
         <div class="icon"><i class="fas fa-user-check"></i></div>
         <h3>ELADEB</h3>
@@ -152,7 +152,7 @@
     </div>
 
     <div class="card">
-      <img src="./illustrations-vignettes/transports-dialyse.png" alt="Logo Transports-dialyse">
+      <img src="./illustrations-vignettes/Transports.png" alt="Logo Transports-dialyse">
       <div class="card-body">
         <div class="icon"><i class="fas fa-ambulance"></i></div>
         <h3>Transports-dialyse</h3>


### PR DESCRIPTION
## Summary
- correct image paths in the main index so GitHub Pages finds the logos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aec4d126c83338acc94e26cd2026b