### PR TITLE
Fix Hospisoc logo proportions

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,11 +29,16 @@
       padding: 2rem 1rem;
     }
     header img {
-      max-width: 450px;
-      width: 100%;
+      max-width: 300px;
       height: auto;
-      margin: 0 auto 20px auto;
       display: block;
+      margin: 0 auto 20px auto;
+    }
+    .logo-hospisoc {
+      max-width: 300px;
+      height: auto;
+      display: block;
+      margin: 0 auto 20px auto;
     }
     header h1 {
       font-size: 2rem;
@@ -132,7 +137,7 @@
 </head>
 <body>
   <header>
-    <img src="./illustrations-vignettes/Logo hospisoc.png" alt="Logo Hospisoc" style="height: 150px;">
+    <img src="./illustrations-vignettes/Logo hospisoc.png" alt="Logo Hospisoc" class="logo-hospisoc">
     <h1>Portail des projets Hospisoc</h1>
     <p>Accès rapide à nos projets en cours</p>
   </header>


### PR DESCRIPTION
## Summary
- update header styling to prevent vertical stretch on logo
- add `.logo-hospisoc` class and apply it to the header image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685aefe9b4ec8333994db1362aa38a25